### PR TITLE
Add support for per-domain user style sheets

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -214,6 +214,7 @@ typedef enum {
     FILES_QUEUE,
 #endif
     FILES_USER_STYLE,
+    FILES_USER_STYLES,
 #ifdef FEATURE_HSTS
     FILES_HSTS,
 #endif


### PR DESCRIPTION
per-domain css files are kept in the XDG_CONFIG/vimb/styles directory.
They are named as [domain].css. For example, a custom style would be
named www.reddit.com.css. This user css file replaces the default
styles.css file, which is still loaded on sites with no user-specified
stylesheet.
